### PR TITLE
Add CPU-only deployment and Canary 1B V2 transcription pipeline

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,0 +1,28 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ffmpeg \
+        libsndfile1 \
+        git \
+        build-essential \
+        ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu "torch==2.3.*" && \
+    pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 9000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9000", "--workers", "1"]

--- a/README.md
+++ b/README.md
@@ -1,142 +1,132 @@
-# Canary-Serve: NVIDIA Canary ASR HTTP API
+# Canary-Serve CPU: NVIDIA Canary 1B V2 ASR HTTP API
 
 **Русский** | [中文](./README.zh.md) | [English](./README.en.md)
 
-Canary-Serve - это минималистичный FastAPI-сервер, позволяющий работать с многоязычными
-`speech-to-text` моделями NVIDIA Canary.
+Актуализированная версия Canary-Serve, адаптированная для работы **только на CPU** и использующая
+предобученную модель [nvidia/canary-1b-v2](https://huggingface.co/nvidia/canary-1b-v2).
+Сервис разворачивается через FastAPI и принимает аудио в форматах **.m4a**, **.wav** и **.flac**.
+Все входы автоматически конвертируются в моно WAV 16 кГц, как этого требует модель.
 
-Он позволяет отправить WAV-файл на единственный маршрут `/inference` и получить текстовый
-результат или субтитры всего за несколько секунд - максимально эффективно используя
-производительность вашей NVIDIA GPU.
+Первый запуск скачает вес модели в смонтированную директорию `./models`, поэтому позаботьтесь о наличии
+достаточного места на диске и свободной оперативной памяти (минимум ~6 ГБ).
 
-## Возможности
+## Основные возможности
 
-* **Отметки времени для слов и сегментов** (только для моделей Flash) через простой флаг timestamps=yes|no.
+- **Работа на CPU** — больше не требуется GPU и CUDA-образ.
+- **Поддержка форматов .m4a/.wav/.flac** — входные файлы автоматически конвертируются в WAV 16 кГц mono через `ffmpeg`.
+- **25 европейских языков** (включая русский) и двунаправленный перевод между ними.
+- **Отметки времени** — при запросе `timestamps=yes` возвращаются сегменты с временными метками, когда модель предоставляет их.
+- **Гибкий формат ответа** — `json`, `verbose_json`, `text`, `srt`, `vtt`.
+- **Лёгкий Docker-образ** на базе `python:3.11-slim` + docker-compose конфигурация для CPU.
 
-* **Переключатель PnC** - возможность включать или отключать автоматическую пунктуацию и капитализацию (PnC).
+## Поддерживаемые языки (ISO 639-1)
 
-* **Обработка длинных аудиофайлов** - автоматическое разбиение аудио длиннее 10 секунд на части, параллельная обработка
-  и последующая сборка.
+| Код | Язык        | Код | Язык        | Код | Язык        |
+|-----|-------------|-----|-------------|-----|-------------|
+| bg  | Болгарский  | hr  | Хорватский  | lt  | Литовский   |
+| cs  | Чешский     | da  | Датский     | lv  | Латышский   |
+| nl  | Нидерландский | en  | Английский  | mt  | Мальтийский |
+| et  | Эстонский   | fi  | Финский     | pl  | Польский    |
+| fr  | Французский | de  | Немецкий    | pt  | Португальский |
+| el  | Греческий   | hu  | Венгерский  | ro  | Румынский   |
+| ga  | Ирландский  | it  | Итальянский | sk  | Словацкий   |
+| sl  | Словенский  | es  | Испанский   | sv  | Шведский    |
+| ru  | Русский     |     |             |     |             |
 
-* **Поддержка нескольких форматов ответов** - text, srt, vtt, json и verbose_json.
-
-* **Docker-Compose с поддержкой GPU** - по умолчанию резервируются все доступные GPU, при этом возможно тонкое
-  управление выбором устройств через стандартный `deploy.resources.reservations.devices`.
-
-* **Zero-copy скачивание моделей** - модели скачиваются один раз
-  через [huggingface_hub.snapshot_download](./canary_api/utils/download_model.py) и кэшируются локально.
-
-* **Компактный образ** - итоговый Docker-образ построен на `nvidia/cuda:12.6.1-devel-ubuntu22.04`, весит около 4.5 ГБ и
-  содержит только необходимые зависимости для выполнения.
-
-## Поддерживаемые модели
-
-* [nvidia/canary-1b](https://huggingface.co/nvidia/canary-1b)
-* [nvidia/canary-1b-flash](https://huggingface.co/nvidia/canary-1b-flash)
-* [nvidia/canary-180m-flash](https://huggingface.co/nvidia/canary-180m-flash)
-
-## Поддерживаемые языки
-
-| ISO | Язык    | ASR | Перевод  | Отметки времени (Flash) |
-|-----|---------|-----|----------|-------------------------|
-| en  | English | +   | de/fr/es | +                       |
-| de  | German  | +   | en       | +                       |
-| fr  | French  | +   | en       | +                       |
-| es  | Spanish | +   | en       | +                       |
-
-> Базовые модели Canary официально поддерживают только эти четыре языка
-> как для распознавания речи (ASR), так и для перевода речи в текст.
+> Модель поддерживает распознавание речи (ASR) и перевод между перечисленными языками.
 
 ## Быстрый старт
 
-### Однострочник для запуска через Docker
+### 1. Сборка и запуск через Docker Compose
 
 ```shell
-docker run --gpus all -it --rm \
-  -p 9000:9000 \
-  -v $(pwd)/models:/app/models \
-  -e CANARY_MODEL_NAME=nvidia/canary-1b-flash \
-  evilfreelancer/canary-serve:latest
+docker compose -f docker-compose.cpu.yml up --build -d
 ```
 
-### Запуск через Docker-Compose
+Сервис запустится на `http://localhost:9000`. Первый запуск может занять несколько минут из-за скачивания модели.
 
-В репозитории доступен актуальный [docker-compose.dist.yml](./docker-compose.dist.yml), который автоматически
-предоставляет доступ к GPU внутри контейнера.
+Чтобы остановить контейнер:
 
 ```shell
-cp docker-compose.dist.yml docker-compose.yml
-docker compose up -d
+docker compose -f docker-compose.cpu.yml down
 ```
 
-## Переменные окружения
+### 2. Проверка готовности
 
-| Variable           | Default                | Purpose                                             |
-|--------------------|------------------------|-----------------------------------------------------|
-| CANARY_MODEL_NAME  | nvidia/canary-1b-flash | Название чекпойнта Canary на Hugging Face           |
-| CANARY_MODEL_PATH  | ./models               | Путь к локальной директории для кэшированной модели |
-| CANARY_BEAM_SIZE   | 1                      | Ширина луча при декодировании                       |
-| CANARY_BATCH_SIZE  | 1                      | Размер батча на запрос                              |
-| CANARY_PNC         | yes                    | yes для включения пунктуации и регистра             |
-| CANARY_TIMESTAMPTS | no                     | yes для активации отметок времени                   |
-| APP_BIND           | 0.0.0.0                | IP-адрес для привязки сервера                       |
-| APP_PORT           | 9000                   | Порт сервера внутри контейнера                      |
-| APP_WORKERS        | 1                      | Количество процессов Uvicorn                        |
+```shell
+curl http://localhost:9000/health
+# => {"status":"ok"}
+```
+
+### 3. Отправка аудио на распознавание
+
+```shell
+curl -s http://localhost:9000/inference \
+  -F "file=@samples/ru_example.m4a" \
+  -F "source_lang=ru" -F "target_lang=ru" \
+  -F "timestamps=yes" -F "response_format=json"
+```
+
+Пример ответа при `response_format=json` и `timestamps=yes`:
+
+```json
+{
+  "text": "Привет, я голосовая модель Canary.",
+  "segments": [
+    {"start": 0.0, "end": 2.4, "text": "Привет"},
+    {"start": 2.4, "end": 4.8, "text": "я голосовая модель Canary"}
+  ]
+}
+```
+
+## Переменные окружения (docker-compose.cpu.yml)
+
+| Переменная  | Значение по умолчанию | Назначение                          |
+|-------------|-----------------------|-------------------------------------|
+| APP_HOST    | 0.0.0.0               | Адрес, на котором слушает Uvicorn   |
+| APP_PORT    | 9000                  | Порт API                            |
+| SOURCE_LANG | ru                    | Язык по умолчанию для входного аудио|
+| TARGET_LANG | ru                    | Язык по умолчанию для транскрипта   |
+| HF_HOME     | /models               | Кэш моделей Hugging Face            |
 
 ## HTTP API
 
 `POST /inference`
 
-* Content-Type: multipart/form-data
-* Поля формы:
-    * `file` WAV-файл (моно/16 кГц), обязательно
-    * `language` en|de|fr|es (по умолчанию en)
-    * `pnc` yes|no (по умолчанию yes)
-    * `timestamps` yes|no (по умолчанию no, доступно только для Flash-моделей)
-    * `beam_size`, `batch_size` (целые числа, опционально)
-    * `response_format` json|text|srt|vtt|verbose_json (по умолчанию text)
+- **Content-Type**: `multipart/form-data`
+- **Поля формы**:
+  - `file` — аудиофайл `.m4a`, `.wav` или `.flac` (обязательно).
+  - `source_lang` — ISO-код языка исходного аудио (по умолчанию `ru`).
+  - `target_lang` — ISO-код языка транскрипта или перевода (по умолчанию `ru`).
+  - `timestamps` — `yes`/`no` (по умолчанию `no`).
+  - `response_format` — `json` | `verbose_json` | `text` | `srt` | `vtt` (по умолчанию `json`).
+  - `beam_size` — ширина луча (целое число, по умолчанию `1`).
+  - `batch_size` — размер батча (целое число, по умолчанию `1`).
 
-**Пример запроса**
+`GET /health`
 
-```shell
-curl http://localhost:9000/inference \
-  -F file=@sample.wav \
-  -F language=de \
-  -F response_format=text
+- Возвращает `{ "status": "ok" }`, когда модель успешно загружена и готова к работе. Пока модель не загружена, маршрут возвращает `503`.
+
+## Ресурсные требования
+
+- **CPU**: современный x86_64 процессор с поддержкой AVX2.
+- **Память**: от 6 ГБ RAM для загрузки модели и буферов.
+- **Диск**: ~3.5 ГБ для артефактов модели в `./models`.
+
+Учтите, что скорость распознавания на CPU ниже, чем на GPU. Для длинных файлов планируйте дополнительные задержки.
+
+## Структура репозитория
+
 ```
-
-Пример успешного ответа в формате JSON:
-
-```json
-{
-  "text": "Guten Tag, hier spricht die KI."
-}
+docker-compose.cpu.yml
+Dockerfile.cpu
+main.py
+canary_api/
+  engine.py
+requirements.txt
+...
 ```
 
 ## Лицензия
 
-Код, Dockerfile и документация этого репозитория распространяются под лицензией MIT - короткой и разрешительной
-лицензией, допускающей как коммерческое, так и частное использование при условии сохранения оригинального авторского
-права и текста лицензии.
-
-## Цитирование
-
-Если вы используете **Canary-Serve** в академических или продакшен проекта, пожалуйста, указывайте ссылку следующим
-образом:
-
-```text
-Pavel Rykov. (2025). Canary-Serve: NVIDIA Canary ASR HTTP API (Version 1.0.0) [Computer software]. GitHub. https://github.com/EvilFreelancer/docker-canary-serve
-```
-
-BibTeX:
-
-```bibtex
-@misc{rykov2025canaryserve,
-    author = {Pavel Rykov},
-    title = {Canary-Serve: NVIDIA Canary ASR HTTP API},
-    howpublished = {\url{https://github.com/EvilFreelancer/docker-canary-serve}},
-    year = {2025},
-    version = {1.0.0},
-    note = {MIT License}
-}
-```
+Проект распространяется по лицензии MIT. Подробности — в файле [LICENSE](./LICENSE).

--- a/canary_api/engine.py
+++ b/canary_api/engine.py
@@ -1,0 +1,182 @@
+"""Model loading and inference helpers for NVIDIA Canary ASR."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from nemo.collections.asr.models import ASRModel
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CanaryEngine:
+    """Lazily loads the Canary model and performs transcription."""
+
+    _instance: Optional["CanaryEngine"] = None
+    _instance_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._model: Optional[ASRModel] = None
+        self._model_lock = threading.Lock()
+        self._model_ready = threading.Event()
+
+    @classmethod
+    def instance(cls) -> "CanaryEngine":
+        if cls._instance is None:
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    def is_ready(self) -> bool:
+        return self._model_ready.is_set()
+
+    def _load_model(self) -> ASRModel:
+        if self._model is None:
+            with self._model_lock:
+                if self._model is None:
+                    _LOGGER.info("Loading NVIDIA Canary model 'nvidia/canary-1b-v2' on CPU…")
+                    model = ASRModel.from_pretrained(model_name="nvidia/canary-1b-v2")
+                    model.to("cpu")
+                    model.eval()
+                    self._model = model
+                    self._model_ready.set()
+        return self._model
+
+    def get_model(self) -> ASRModel:
+        return self._load_model()
+
+    def transcribe(
+        self,
+        audio_path: Path,
+        source_lang: str,
+        target_lang: str,
+        timestamps: bool,
+        beam_size: Optional[int] = None,
+        batch_size: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Run transcription and return text plus optional segments."""
+
+        model = self._load_model()
+
+        kwargs: Dict[str, Any] = {}
+        if source_lang:
+            kwargs["source_lang"] = source_lang
+        if target_lang:
+            kwargs["target_lang"] = target_lang
+        if beam_size is not None:
+            kwargs["beam_size"] = beam_size
+        if batch_size is not None:
+            kwargs["batch_size"] = batch_size
+
+        use_hypotheses = timestamps
+        if timestamps:
+            kwargs["return_hypotheses"] = True
+
+        result: Any = None
+        attempt_kwargs = dict(kwargs)
+
+        while True:
+            try:
+                result = model.transcribe([str(audio_path)], **attempt_kwargs)
+                break
+            except TypeError as exc:
+                if not attempt_kwargs:
+                    raise
+                key, _ = attempt_kwargs.popitem()
+                _LOGGER.warning("Model.transcribe rejected argument '%s': %s", key, exc)
+                if key == "return_hypotheses":
+                    use_hypotheses = False
+            except Exception:
+                _LOGGER.exception("Canary transcription failed")
+                raise
+
+        text, segments = _parse_transcription_output(result, use_hypotheses)
+        return {"text": text, "segments": segments}
+
+
+def _parse_transcription_output(result: Any, use_hypotheses: bool) -> tuple[str, List[Dict[str, Any]]]:
+    text: str = ""
+    segments: List[Dict[str, Any]] = []
+
+    if isinstance(result, list) and result:
+        first = result[0]
+        if hasattr(first, "text"):
+            text = getattr(first, "text") or ""
+        elif isinstance(first, str):
+            text = first
+        else:
+            text = str(first)
+
+        if use_hypotheses and hasattr(first, "segments"):
+            raw_segments = getattr(first, "segments") or []
+            segments = _convert_segments(raw_segments)
+        elif use_hypotheses and hasattr(first, "words"):
+            raw_segments = getattr(first, "words") or []
+            segments = _convert_word_segments(raw_segments)
+        elif isinstance(first, str):
+            text = first
+    elif isinstance(result, str):
+        text = result
+
+    text = text.strip()
+
+    if not segments:
+        segments = []
+
+    return text, segments
+
+
+def _convert_segments(raw_segments: Any) -> List[Dict[str, Any]]:
+    converted: List[Dict[str, Any]] = []
+    for seg in raw_segments:
+        start = _safe_get(seg, "start_time", "start", "start_offset")
+        end = _safe_get(seg, "end_time", "end", "end_offset")
+        content = _safe_get(seg, "text", "content", default="")
+        if start is None or end is None:
+            continue
+        converted.append(
+            {
+                "start": float(start),
+                "end": float(end),
+                "text": str(content).strip(),
+            }
+        )
+    return converted
+
+
+def _convert_word_segments(raw_segments: Any) -> List[Dict[str, Any]]:
+    converted: List[Dict[str, Any]] = []
+    for word in raw_segments:
+        start = _safe_get(word, "start_time", "start_offset", "start")
+        end = _safe_get(word, "end_time", "end_offset", "end")
+        token = _safe_get(word, "text", "word", default="")
+        if start is None or end is None:
+            continue
+        converted.append(
+            {
+                "start": float(start),
+                "end": float(end),
+                "text": str(token).strip(),
+            }
+        )
+    return converted
+
+
+def _safe_get(obj: Any, *keys: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        for key in keys:
+            if key in obj:
+                return obj[key]
+    else:
+        for key in keys:
+            if hasattr(obj, key):
+                return getattr(obj, key)
+    return default
+
+
+def load_engine() -> CanaryEngine:
+    return CanaryEngine.instance()

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,0 +1,16 @@
+services:
+  canary:
+    build:
+      context: .
+      dockerfile: Dockerfile.cpu
+    ports:
+      - "9000:9000"
+    environment:
+      APP_HOST: "0.0.0.0"
+      APP_PORT: "9000"
+      SOURCE_LANG: "ru"
+      TARGET_LANG: "ru"
+      HF_HOME: "/models"
+    volumes:
+      - ./models:/models
+    command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9000", "--workers", "1"]

--- a/main.py
+++ b/main.py
@@ -1,15 +1,231 @@
-from fastapi import FastAPI
-from canary_api.endpoints.transcriptions_endpoint import router as asr_router
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import soundfile as sf
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.responses import JSONResponse, PlainTextResponse, Response
+
+from canary_api.engine import load_engine
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+)
+LOGGER = logging.getLogger("canary.api")
+
+DEFAULT_SOURCE_LANG = os.getenv("SOURCE_LANG", "ru")
+DEFAULT_TARGET_LANG = os.getenv("TARGET_LANG", "ru")
+MAX_FILE_SIZE_BYTES = int(os.getenv("MAX_FILE_SIZE", str(200 * 1024 * 1024)))
+SUPPORTED_EXTENSIONS = {".wav", ".m4a", ".flac"}
+MODEL_NAME = "nvidia/canary-1b-v2"
+
+engine = load_engine()
 
 app = FastAPI(
-    title="Nvidia Canary ASR API",
-    version="1.0.0",
-    description="OpenAI-compatible API for Nvidia Canary models"
+    title="NVIDIA Canary 1B V2 ASR API",
+    version="2.0.0",
+    description="FastAPI server for CPU inference with NVIDIA Canary 1B V2",
 )
 
-app.include_router(asr_router)
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    LOGGER.info("Application startup: ensuring model is loaded.")
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, engine.get_model)
+    LOGGER.info("Model loaded and ready for inference.")
+
+
+@app.get("/health")
+async def health() -> Dict[str, str]:
+    if not engine.is_ready():
+        raise HTTPException(status_code=503, detail="Model is still loading")
+    return {"status": "ok"}
+
+
+@app.post("/inference")
+async def run_inference(
+    file: UploadFile = File(...),
+    source_lang: str = Form(DEFAULT_SOURCE_LANG),
+    target_lang: str = Form(DEFAULT_TARGET_LANG),
+    timestamps: str = Form("no"),
+    response_format: str = Form("json"),
+    beam_size: int = Form(1),
+    batch_size: int = Form(1),
+) -> Response:
+    if not file.filename:
+        raise HTTPException(status_code=400, detail="Uploaded file must have a filename")
+
+    extension = Path(file.filename).suffix.lower()
+    if extension not in SUPPORTED_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported file type '{extension}'. Allowed extensions: {', '.join(sorted(SUPPORTED_EXTENSIONS))}",
+        )
+
+    timestamps_requested = _parse_bool(timestamps)
+    response_format_normalized = response_format.strip().lower()
+    if response_format_normalized not in {"json", "verbose_json", "text", "srt", "vtt"}:
+        raise HTTPException(status_code=400, detail="Unsupported response_format value")
+
+    need_segments = timestamps_requested or response_format_normalized in {"srt", "vtt"}
+
+    with tempfile.TemporaryDirectory(prefix="canary_") as tmp_dir:
+        tmp_dir_path = Path(tmp_dir)
+        input_path = tmp_dir_path / f"input{extension}"
+        file_size = await _save_upload_to_disk(file, input_path)
+        if file_size == 0:
+            raise HTTPException(status_code=400, detail="Uploaded file is empty")
+        if file_size > MAX_FILE_SIZE_BYTES:
+            raise HTTPException(status_code=413, detail="Uploaded file is too large")
+
+        processed_path = _prepare_audio(input_path, extension, tmp_dir_path)
+
+        try:
+            result = engine.transcribe(
+                processed_path,
+                source_lang=source_lang,
+                target_lang=target_lang,
+                timestamps=need_segments,
+                beam_size=beam_size,
+                batch_size=batch_size,
+            )
+        except Exception as exc:  # pragma: no cover - propagated to client
+            LOGGER.exception("Inference failed")
+            raise HTTPException(status_code=500, detail=f"Inference failed: {exc}") from exc
+
+    text = result.get("text", "").strip()
+    segments = result.get("segments", []) if need_segments else []
+
+    if response_format_normalized == "json":
+        payload: Dict[str, object] = {"text": text}
+        if timestamps_requested:
+            payload["segments"] = segments
+        return JSONResponse(content=payload)
+
+    if response_format_normalized == "verbose_json":
+        verbose_payload = {
+            "text": text,
+            "model": MODEL_NAME,
+            "source_lang": source_lang,
+            "target_lang": target_lang,
+            "segments": segments,
+        }
+        return JSONResponse(content=verbose_payload)
+
+    if response_format_normalized == "text":
+        return PlainTextResponse(content=text)
+
+    formatted_segments = segments if segments else [{"start": 0.0, "end": 0.0, "text": text}]
+
+    if response_format_normalized == "srt":
+        return PlainTextResponse(content=_segments_to_srt(formatted_segments), media_type="application/x-subrip")
+
+    if response_format_normalized == "vtt":
+        return PlainTextResponse(content=_segments_to_vtt(formatted_segments), media_type="text/vtt")
+
+    raise HTTPException(status_code=500, detail="Unhandled response format")
+
+
+async def _save_upload_to_disk(upload: UploadFile, destination: Path) -> int:
+    size = 0
+    with destination.open("wb") as buffer:
+        while True:
+            chunk = await upload.read(1024 * 1024)
+            if not chunk:
+                break
+            size += len(chunk)
+            buffer.write(chunk)
+    await upload.close()
+    return size
+
+
+def _prepare_audio(input_path: Path, extension: str, tmp_dir_path: Path) -> Path:
+    if extension != ".wav":
+        return _convert_to_wav(input_path, tmp_dir_path)
+
+    try:
+        info = sf.info(str(input_path))
+        if info.samplerate == 16000 and info.channels == 1:
+            return input_path
+        LOGGER.info("Re-sampling WAV file from %s Hz / %s channels", info.samplerate, info.channels)
+    except RuntimeError:
+        LOGGER.info("soundfile could not read WAV metadata, forcing conversion")
+
+    return _convert_to_wav(input_path, tmp_dir_path)
+
+
+def _convert_to_wav(input_path: Path, tmp_dir_path: Path) -> Path:
+    output_path = tmp_dir_path / "converted.wav"
+    command = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(input_path),
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        str(output_path),
+    ]
+    LOGGER.info("Running ffmpeg conversion: %s", " ".join(command))
+    try:
+        completed = subprocess.run(command, capture_output=True, check=True)
+        if completed.stderr:
+            LOGGER.debug("ffmpeg stderr: %s", completed.stderr.decode(errors="ignore"))
+    except subprocess.CalledProcessError as exc:
+        LOGGER.error("ffmpeg conversion failed: %s", exc.stderr.decode(errors="ignore"))
+        raise HTTPException(status_code=500, detail="Failed to convert audio to WAV") from exc
+    return output_path
+
+
+def _parse_bool(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _format_timestamp(seconds: float, separator: str) -> str:
+    total_ms = max(seconds, 0.0) * 1000.0
+    hours = int(total_ms // 3_600_000)
+    minutes = int((total_ms % 3_600_000) // 60_000)
+    secs = (total_ms % 60_000) / 1000.0
+    if separator == ",":
+        return f"{hours:02}:{minutes:02}:{secs:06.3f}".replace(".", ",")
+    return f"{hours:02}:{minutes:02}:{secs:06.3f}"
+
+
+def _segments_to_srt(segments: Iterable[Dict[str, object]]) -> str:
+    lines: List[str] = []
+    for idx, segment in enumerate(segments, start=1):
+        start = float(segment.get("start", 0.0))
+        end = float(segment.get("end", start))
+        text = str(segment.get("text", "")).strip()
+        lines.append(str(idx))
+        lines.append(f"{_format_timestamp(start, ',')} --> {_format_timestamp(end, ',')}")
+        lines.append(text)
+        lines.append("")
+    return "\n".join(lines).strip() + "\n"
+
+
+def _segments_to_vtt(segments: Iterable[Dict[str, object]]) -> str:
+    lines: List[str] = ["WEBVTT", ""]
+    for segment in segments:
+        start = float(segment.get("start", 0.0))
+        end = float(segment.get("end", start))
+        text = str(segment.get("text", "")).strip()
+        lines.append(f"{_format_timestamp(start, '.')} --> {_format_timestamp(end, '.')}")
+        lines.append(text)
+        lines.append("")
+    return "\n".join(lines).strip() + "\n"
+
 
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host=os.getenv("APP_HOST", "0.0.0.0"), port=int(os.getenv("APP_PORT", "9000")))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,30 +1,7 @@
-# API
-fastapi~=0.115.12
-uvicorn~=0.34.2
-python-multipart~=0.0.20
-
-# Core
-pydantic~=2.11.3
-pydantic-settings~=2.9.1
-huggingface-hub~=0.30.2
-fire~=0.7.0
-srt~=3.5.3
-
-# Inference
-nemo-toolkit==2.3.0rc4
-torch~=2.6.0
-hydra-core~=1.3.2
-pytorch-lightning~=2.5.1
-lhotse~=1.31.0
-einops~=0.8.1
-transformers~=4.51.3
-sentencepiece~=0.2.0
-pandas~=2.2.3
-jiwer~=3.1.0
-librosa~=0.11.0
-pyannote.audio~=3.3.2
-webdataset~=0.2.111
-datasets~=3.5.0
-editdistance~=0.8.1
-ipython~=8.36.0
-pydub~=0.25.1
+fastapi==0.115.6
+uvicorn[standard]==0.34.0
+python-multipart==0.0.12
+pydantic==2.9.2
+soundfile==0.12.1
+numpy==1.26.4
+nemo-toolkit[asr]==2.0.0rc0


### PR DESCRIPTION
## Summary
- add a slim Python 3.11 CPU Dockerfile and compose profile that downloads Canary models into a shared volume
- implement a lazy-loading Canary 1B V2 inference engine with FastAPI support for m4a/wav/flac uploads, timestamps, and multiple response formats
- refresh requirements and Russian README instructions for CPU usage, supported languages, and usage examples

## Testing
- python -m compileall main.py canary_api/engine.py

------
https://chatgpt.com/codex/tasks/task_e_68de401f6e8c8325913fa014795d3f82