### PR TITLE
Restrict huggingface-hub version to maintain NeMo compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pydantic==2.9.2
 soundfile==0.12.1
 numpy==1.26.4
 nemo-toolkit[asr]==2.0.0rc0
-huggingface-hub>=0.25.0
+huggingface-hub>=0.25.0,<0.30.0


### PR DESCRIPTION
## Summary
- constrain huggingface-hub to versions below 0.30.0 to retain NeMo ModelFilter export

## Testing
- `pip install -r requirements.txt` *(fails: ProxyError - tunnel connection failed)*
- `python main.py` *(fails: ProxyError while downloading nvidia/canary-1b-v2 model)*

------
https://chatgpt.com/codex/tasks/task_e_68de4a804380832587732452c4d8d115